### PR TITLE
Added Altera/Intel constraint context and switch name

### DIFF
--- a/syntaxes/Synopsys Design Constraints.sublime-syntax
+++ b/syntaxes/Synopsys Design Constraints.sublime-syntax
@@ -12,6 +12,7 @@ contexts:
       with_prototype:
         - include: standard-parameters
         - include: xilinx-parameters-extensions
+        - include: intel-parameters-extensions
 
   standard-parameters:
     - match: |-
@@ -50,6 +51,14 @@ contexts:
         1: punctuation.separator.switch.sdc
         2: support.type.xilinx.sdc
 
+  intel-parameters-extensions:
+    - match: |-
+        (?xi)\s(\+|\-)(
+          reference_pin
+        )\b
+      captures:
+        1: punctuation.separator.switch.sdc
+        2: support.type.intel.sdc
 
 
 


### PR DESCRIPTION
I ran into this while working on some input constraints for the project at work I'm on.  The timing model got a lot simpler with the `-reference_pin` switch on `set_input_delay`.  So since I still had my repository for the SDC Constraints I added a syntax context for Intel specific constructs (we already had one for Xilinx) and it seems to work okay.  Figured I'd suggest this get rolled into the main.